### PR TITLE
fix/not-enough-values-to-unpack

### DIFF
--- a/PythonProjects/Libraries/Freenove_Micro_Rover.py
+++ b/PythonProjects/Libraries/Freenove_Micro_Rover.py
@@ -19,10 +19,10 @@ class Micro_Rover(object):
         i2c.write(self.add, bytearray([0x00, mode1]), repeat=False)
         sleep(5)
     def set_pwm(self, channel, on, off):
-        if on is None or off is None:
-            i2c.writ(self.add, bytearray([0x06+4*channel]), repeat=False)
-            data = i2c.read(self.add, 4)
-            return ustruct.unpack('<HH', data)
+        # if on is None or off is None:
+        #     i2c.writ(self.add, bytearray([0x06+4*channel]), repeat=False)
+        #     data = i2c.read(self.add, 4)
+        #     return ustruct.unpack('<HH', data)
         i2c.write(self.add, bytearray([0x06+4*channel, on & 0xFF]), repeat=False)
         i2c.write(self.add, bytearray([0x07+4*channel, on >> 8]), repeat=False)
         i2c.write(self.add, bytearray([0x08+4*channel, off & 0xFF]), repeat=False)


### PR DESCRIPTION
Got "ValueError: not enough values to unpack (expected 2, got 1)" when loading the file into the micro:bit (v2, firmware 0255) with Code with Mu, I solved the issue by removing the unpack instruction (as is already the case in line 16).

Fixes #1.